### PR TITLE
Chore: expand on anchor-is-invalid rule

### DIFF
--- a/rules/react-a11y.js
+++ b/rules/react-a11y.js
@@ -16,6 +16,7 @@ module.exports = {
   rules: {
     'jsx-a11y/anchor-is-valid': ['error', {
       components: ['Link'], // Don't assume a <Link /> component is invalid
+      specialLink: [ "to" ],
     }],
     'jsx-a11y/media-has-caption': 0,
   },


### PR DESCRIPTION
While working on the ACB Stories website I used the following code `<Link to="/">Homepage</Link>` which generated the following error:

```
The href attribute is required for an anchor to be keyboard accessible. Provide a valid, navigable address as the href value. If you cannot provide an href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md
```